### PR TITLE
🍰 GitHub issue template meta data

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,6 +1,8 @@
 ---
 name: 🐛 Bug Report
 about: Report any bug or defect you've come accross when using CMaNGOS.
+labels: bug
+title: 🐛 [Bug] 
 ---
 
 ## 🐛 Bugreport

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -19,7 +19,7 @@ title: 🐛 [Bug]
   - "2.4.3" (TBC)
   - "3.3.5a" (WOTLK)
 -->
-Client Version: []
+Client Version: 
 
 <!--
   Commit Hash - is required
@@ -30,7 +30,7 @@ Client Version: []
 
   To find XXXX use "git log -1 --format=%H" in your local CMaNGOS repo
 -->
-CMaNGOS Repo & Commit Hash:  []()
+CMaNGOS Repo & Commit Hash: 
 
 <!--
   Database Version - is required
@@ -41,7 +41,7 @@ CMaNGOS Repo & Commit Hash:  []()
 
   To find XXXX use "git log -1 --format=%H" in your local Database repo
 -->
-Database Repo & Commit Hash: []()
+Database Repo & Commit Hash: 
 
 <!--
   Operating System - optional
@@ -50,7 +50,7 @@ Database Repo & Commit Hash: []()
   - MacOS XX
   - Linux Flavor
 -->
-Operating System: []
+Operating System: 
 
 ### Steps to reproduce
 1.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,8 +1,8 @@
 ---
 name: 🐛 Bug Report
 about: Report any bug or defect you've come accross when using CMaNGOS.
-labels: bug
-title: 🐛 [Bug] 
+labels: "Info: Needs Replication"
+title: 🐛 [Bug Report] 
 ---
 
 ## 🐛 Bugreport

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -1,8 +1,8 @@
 ---
 name: 🚀 Feature
 about: Ask for a well defined and described Feature for CMaNGOS.
-labels: feature
-title: 🚀 [Feature] 
+labels: "Type: Feature Request"
+title: 🚀 [Feature Request] 
 ---
 
 ## 🚀 Feature

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -1,6 +1,8 @@
 ---
 name: 🚀 Feature
 about: Ask for a well defined and described Feature for CMaNGOS.
+labels: feature
+title: 🚀 [Feature] 
 ---
 
 ## 🚀 Feature

--- a/.github/ISSUE_TEMPLATE/support_question.md
+++ b/.github/ISSUE_TEMPLATE/support_question.md
@@ -1,6 +1,8 @@
 ---
 name: 💬 Support Question
 about: Ask a Question of the developers if you need help understanding CMaNGOS.
+labels: question
+title: 💬 [Question] 
 ---
 <!-- Chat with the CMangos DevTeam -->
 <!-- Support on Github is limited! Refer to Discord to engage directly with the developers

--- a/.github/ISSUE_TEMPLATE/support_question.md
+++ b/.github/ISSUE_TEMPLATE/support_question.md
@@ -20,7 +20,7 @@ regarding Usage and Development of CMaNGOS; CMaNGOS Discord: https://discord.gg/
   - "2.4.3" (TBC)
   - "3.3.5a" (WOTLK)
 -->
-Client Version: []
+Client Version: 
 
 <!--
   Commit Hash - is required
@@ -31,7 +31,7 @@ Client Version: []
 
   To find XXXX use "git log -1 --format=%H" in your local CMaNGOS repo
 -->
-CMaNGOS Repo & Commit Hash:  []()
+CMaNGOS Repo & Commit Hash:  
 
 <!--
   Database Version - is required
@@ -42,7 +42,7 @@ CMaNGOS Repo & Commit Hash:  []()
 
   To find XXXX use "git log -1 --format=%H" in your local Database repo
 -->
-Database Repo & Commit Hash: []()
+Database Repo & Commit Hash: 
 
 <!--
   Operating System - optional
@@ -51,7 +51,7 @@ Database Repo & Commit Hash: []()
   - MacOS XX
   - Linux Flavor
 -->
-Operating System: []
+Operating System: 
 
 ### Steps to reproduce
 1.

--- a/.github/ISSUE_TEMPLATE/support_request.md
+++ b/.github/ISSUE_TEMPLATE/support_request.md
@@ -1,15 +1,15 @@
 ---
-name: 💬 Support Question
+name: 💬 Support Request
 about: Ask a Question of the developers if you need help understanding CMaNGOS.
-labels: question
-title: 💬 [Question] 
+labels: "Type: Support"
+title: 💬 [Support Request] 
 ---
 <!-- Chat with the CMangos DevTeam -->
 <!-- Support on Github is limited! Refer to Discord to engage directly with the developers
 regarding Usage and Development of CMaNGOS; CMaNGOS Discord: https://discord.gg/rBaNJRT -->
 
-## 💬 Support Question
-<!-- Describe your Question in detail. Include screenshots and drawings if needed. -->
+## 💬 Support Request
+<!-- Describe your request in detail. Include screenshots and drawings if needed. -->
 
 ### Version & Environment
 <!-- Provide these infos if available and applicable -->


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
This PR adds the new Metadata of Github Issue Templates to the header of each Template.

This Metadata is:
- A default Title
- A default Label

A Screenshot showing the default label and default title (marked) of a bugreport.
![image](https://user-images.githubusercontent.com/1238238/58498643-c1468f00-817e-11e9-900e-7740ad42f93c.png)
(Note that this Screenshot is from a different Repo and does not reassemble our bugreport template)

This results in iconized Issue Lists like so:
![image](https://user-images.githubusercontent.com/1238238/58499694-f9e76800-8180-11e9-803f-bd18bf52e55b.png)

-------

This PR also removes the empty markdown link syntax from the Client Version, Commit Hashes and OS Version since its widely misused.

### Proof
<!-- Link resources as proof -->
- More info here: https://help.github.com/en/articles/manually-creating-a-single-issue-template-for-your-repository (point 5)

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- Requires merge before testing

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [x] The used default Labels `question`, `bug` and `feature` are not present in this Repository. Either create them, leave out this feature or use different labels from the existing set.
- [ ] Do we want those features in the Templates? - discuss
- [ ] There is also the option to assign default assignees - discuss